### PR TITLE
fixes for lambda expressions

### DIFF
--- a/src/examples/calc.test.ts
+++ b/src/examples/calc.test.ts
@@ -1,28 +1,13 @@
-import { assert, equal } from "../../deps/std.ts";
-import { Calc, calc } from "./calc.ts";
+import { Calc } from "./calc.ts";
 import { tests } from "../test.ts";
 
-Deno.test({
-  name: "CALC00",
-  fn: () => {
-    const { matched, end, value, errors } = calc`7 + 11`;
-    const actual = { matched, done: end.stream.done, value, errors };
-    const expected = {
-      matched: true,
-      done: true,
-      value: 18,
-      errors: [],
-    };
-    assert(
-      equal(expected, actual),
-      `Expected:\n${
-        Deno.inspect(expected, { colors: true, depth: 5 })
-      }\nActual:\n${Deno.inspect(actual, { colors: true, depth: 5 })}`,
-    );
-  },
-});
-
 tests(() => [
+  {
+    id: "CALC00",
+    pattern: () => Calc,
+    input: "7",
+    value: 7,
+  },
   {
     id: "CALC01",
     pattern: () => Calc,

--- a/src/examples/calc.ts
+++ b/src/examples/calc.ts
@@ -3,16 +3,16 @@ import { Pattern } from "../runtime/patterns/mod.ts";
 
 const match = uffda`
   Number
-    = { type = 'Integer', i:value } -> ${({ i }) => i}
+    = ({ type = 'Integer', i:value } -> ${({ i }) => i})
     ;
     
   Sub
-    = l:Sub { type = 'Token', value = '-' } r:Number -> ${({ l, r }) => l - r}
+    = (l:Sub { type = 'Token', value = '-' } r:Number -> ${({ l, r }) => l - r})
     | Number
     ;
 
   Add
-    = l:Add { type = 'Token', value = '+' } r:Sub -> ${({ l, r }) => l + r}
+    = (l:Add { type = 'Token', value = '+' } r:Sub -> ${({ l, r }) => l + r})
     | Sub
     ;
 

--- a/src/parsers/compiler/ExpressionCompiler.ts
+++ b/src/parsers/compiler/ExpressionCompiler.ts
@@ -1,6 +1,6 @@
 import { IRulePattern, PatternKind } from "../../runtime/patterns/mod.ts";
 import { ExpressionLang } from "../lang/ExpressionLang.ts";
-import { ExpressionPattern } from "./patterns/mod.ts";
+import * as Patterns from "./patterns/mod.ts";
 import * as Expressions from "./expressions/mod.ts";
 
 export const ExpressionCompiler: IRulePattern = {
@@ -9,7 +9,7 @@ export const ExpressionCompiler: IRulePattern = {
     kind: PatternKind.Block,
     rules: {
       ExpressionLang,
-      ExpressionPattern,
+      ...Patterns,
       ...Expressions,
       Main: {
         kind: PatternKind.Rule,

--- a/src/parsers/compiler/expressions/LambdaExpression.test.ts
+++ b/src/parsers/compiler/expressions/LambdaExpression.test.ts
@@ -1,0 +1,85 @@
+import { tests } from "../../../test.ts";
+import { ExpressionKind } from "../../../runtime/expressions/mod.ts";
+import { ExpressionCompiler } from "../ExpressionCompiler.ts";
+import { PatternKind } from "../../../runtime/patterns/pattern.kind.ts";
+
+tests(() => [
+  {
+    id: "COMPILER.EXPRESSION.LAMBDA00",
+    pattern: () => ExpressionCompiler,
+    input: "(a -> a)",
+    value: {
+      kind: ExpressionKind.Lambda,
+      pattern: {
+        kind: PatternKind.Reference,
+        name: "a",
+      },
+      expression: {
+        kind: ExpressionKind.Reference,
+        name: "a",
+      },
+    },
+  },
+
+  {
+    id: "COMPILER.EXPRESSION.LAMBDA01",
+    pattern: () => ExpressionCompiler,
+    input: "(a | b -> _)",
+    value: {
+      kind: ExpressionKind.Lambda,
+      pattern: {
+        kind: PatternKind.Or,
+        patterns: [
+          {
+            kind: PatternKind.Reference,
+            name: "a",
+          },
+          {
+            kind: PatternKind.Reference,
+            name: "b",
+          },
+        ],
+      },
+      expression: {
+        kind: ExpressionKind.Reference,
+        name: "_",
+      },
+    },
+  },
+  {
+    id: "COMPILER.EXPRESSION.LAMBDA02",
+    pattern: () => ExpressionCompiler,
+    input: "(map items (i -> i + i))",
+    value: {
+      kind: ExpressionKind.Invocation,
+      expression: {
+        kind: ExpressionKind.Reference,
+        name: "map",
+      },
+      args: [
+        {
+          kind: ExpressionKind.Reference,
+          name: "items",
+        },
+        {
+          kind: ExpressionKind.Lambda,
+          pattern: {
+            kind: PatternKind.Reference,
+            name: "i",
+          },
+          expression: {
+            kind: ExpressionKind.Add,
+            left: {
+              kind: ExpressionKind.Reference,
+              name: "i",
+            },
+            right: {
+              kind: ExpressionKind.Reference,
+              name: "i",
+            },
+          },
+        },
+      ],
+    },
+  },
+]);

--- a/src/parsers/compiler/expressions/LambdaExpression.ts
+++ b/src/parsers/compiler/expressions/LambdaExpression.ts
@@ -1,18 +1,25 @@
 import { IRulePattern, PatternKind } from "../../../runtime/patterns/mod.ts";
 import { ExpressionKind } from "../../../runtime/expressions/mod.ts";
+import { LangExpressionKind } from "../../lang/lang.pattern.ts";
 
-export const ProjectionPattern: IRulePattern = {
+export const LambdaExpression: IRulePattern = {
   kind: PatternKind.Rule,
   pattern: {
     kind: PatternKind.Projection,
     pattern: {
       kind: PatternKind.Object,
       keys: {
-        kind: { kind: PatternKind.Equal, value: "ProjectionPattern" },
+        kind: {
+          kind: PatternKind.Equal,
+          value: LangExpressionKind.LambdaExpression,
+        },
         pattern: {
           kind: PatternKind.Variable,
           name: "pattern",
-          pattern: { kind: PatternKind.Reference, name: "PatternPattern" },
+          pattern: {
+            kind: PatternKind.Reference,
+            name: "PatternPattern",
+          },
         },
         expression: {
           kind: PatternKind.Variable,
@@ -27,7 +34,7 @@ export const ProjectionPattern: IRulePattern = {
     expression: {
       kind: ExpressionKind.Native,
       fn: ({ pattern, expression }) => ({
-        kind: PatternKind.Projection,
+        kind: ExpressionKind.Lambda,
         pattern,
         expression,
       }),

--- a/src/parsers/compiler/expressions/NumberExpression.test.ts
+++ b/src/parsers/compiler/expressions/NumberExpression.test.ts
@@ -1,0 +1,31 @@
+import { tests } from "../../../test.ts";
+import { ExpressionKind } from "../../../runtime/expressions/mod.ts";
+import { ExpressionCompiler } from "../ExpressionCompiler.ts";
+
+tests(() => [
+  {
+    id: "COMPILER.EXPRESSION.NUMBER00",
+    pattern: () => ExpressionCompiler,
+    input: "1",
+    value: {
+      kind: ExpressionKind.Value,
+      value: 1,
+    },
+  },
+  {
+    id: "COMPILER.EXPRESSION.NUMBER01",
+    pattern: () => ExpressionCompiler,
+    input: "7 + 11",
+    value: {
+      kind: ExpressionKind.Add,
+      left: {
+        kind: ExpressionKind.Value,
+        value: 7,
+      },
+      right: {
+        kind: ExpressionKind.Value,
+        value: 11,
+      },
+    },
+  },
+]);

--- a/src/parsers/compiler/expressions/NumberExpression.ts
+++ b/src/parsers/compiler/expressions/NumberExpression.ts
@@ -1,0 +1,31 @@
+import { IRulePattern, PatternKind } from "../../../runtime/patterns/mod.ts";
+import { ExpressionKind } from "../../../runtime/expressions/mod.ts";
+import { LangExpressionKind } from "../../lang/lang.pattern.ts";
+
+export const NumberExpression: IRulePattern = {
+  kind: PatternKind.Rule,
+  pattern: {
+    kind: PatternKind.Projection,
+    pattern: {
+      kind: PatternKind.Object,
+      keys: {
+        kind: {
+          kind: PatternKind.Equal,
+          value: LangExpressionKind.NumberExpression,
+        },
+        value: {
+          kind: PatternKind.Variable,
+          name: "value",
+          pattern: { kind: PatternKind.Number },
+        },
+      },
+    },
+    expression: {
+      kind: ExpressionKind.Native,
+      fn: ({ value }) => ({
+        kind: ExpressionKind.Value,
+        value,
+      }),
+    },
+  },
+};

--- a/src/parsers/compiler/expressions/mod.ts
+++ b/src/parsers/compiler/expressions/mod.ts
@@ -1,5 +1,7 @@
 export * from "./AddExpression.ts";
 export * from "./ArrayExpression.ts";
 export * from "./InvocationExpression.ts";
+export * from "./LambdaExpression.ts";
+export * from "./NumberExpression.ts";
 export * from "./ReferenceExpression.ts";
 export * from "./SpecialReferenceExpression.ts";

--- a/src/parsers/compiler/patterns/ExpressionPattern.ts
+++ b/src/parsers/compiler/patterns/ExpressionPattern.ts
@@ -20,6 +20,14 @@ export const ExpressionPattern: IRulePattern = {
       },
       {
         kind: PatternKind.Reference,
+        name: LangExpressionKind.LambdaExpression,
+      },
+      {
+        kind: PatternKind.Reference,
+        name: LangExpressionKind.NumberExpression,
+      },
+      {
+        kind: PatternKind.Reference,
         name: LangExpressionKind.SpecialReferenceExpression,
       },
       {

--- a/src/parsers/compiler/patterns/ProjectionPattern.test.ts
+++ b/src/parsers/compiler/patterns/ProjectionPattern.test.ts
@@ -6,10 +6,9 @@ import { PatternCompiler } from "../PatternCompiler.ts";
 const $0 = () => {};
 tests(() => [
   {
-    id: "PROJECTIONPATTERN00",
-    description: "a -> $0",
+    id: "COMPILER.PATTERN.PROJECTION00",
     pattern: () => PatternCompiler,
-    input: "a -> $0",
+    input: "(a -> $0)",
     specials: { $0 },
     value: {
       kind: PatternKind.Projection,
@@ -20,6 +19,50 @@ tests(() => [
       expression: {
         kind: ExpressionKind.Native,
         fn: $0,
+      },
+    },
+  },
+  {
+    id: "COMPILER.PATTERN.PROJECTION02",
+    pattern: () => PatternCompiler,
+    input: `
+      (items:any ->
+        (
+          map
+          items
+          (i:any -> i + 1)
+        )
+      )
+    `,
+    value: {
+      kind: PatternKind.Projection,
+      pattern: {
+        kind: PatternKind.Variable,
+        name: "items",
+        pattern: { kind: PatternKind.Any },
+      },
+      expression: {
+        kind: ExpressionKind.Invocation,
+        expression: {
+          kind: ExpressionKind.Reference,
+          name: "map",
+        },
+        args: [
+          { kind: ExpressionKind.Reference, name: "items" },
+          {
+            kind: ExpressionKind.Lambda,
+            pattern: {
+              kind: PatternKind.Variable,
+              name: "i",
+              pattern: { kind: PatternKind.Any },
+            },
+            expression: {
+              kind: ExpressionKind.Add,
+              left: { kind: ExpressionKind.Reference, name: "i" },
+              right: { kind: ExpressionKind.Value, value: 1 },
+            },
+          },
+        ],
       },
     },
   },

--- a/src/parsers/lang/expressions/LambdaExpression.test.ts
+++ b/src/parsers/lang/expressions/LambdaExpression.test.ts
@@ -6,7 +6,7 @@ tests(() => [
   {
     id: "LANG.LAMBDA00",
     pattern: () => ExpressionLang,
-    input: "a -> a",
+    input: "(a -> a)",
     value: {
       kind: LangExpressionKind.LambdaExpression,
       pattern: { kind: LangPatternKind.ReferencePattern, name: "a" },
@@ -16,7 +16,7 @@ tests(() => [
   {
     id: "LANG.LAMBDA01",
     pattern: () => ExpressionLang,
-    input: "a -> a + 1",
+    input: "(a -> a + 1)",
     value: {
       kind: LangExpressionKind.LambdaExpression,
       pattern: { kind: LangPatternKind.ReferencePattern, name: "a" },
@@ -36,7 +36,7 @@ tests(() => [
   {
     id: "LANG.LAMBDA02",
     pattern: () => ExpressionLang,
-    input: "a -> b -> a + b",
+    input: "(a -> (b -> a + b))",
     value: {
       kind: LangExpressionKind.LambdaExpression,
       pattern: { kind: LangPatternKind.ReferencePattern, name: "a" },
@@ -54,6 +54,57 @@ tests(() => [
             name: "b",
           },
         },
+      },
+    },
+  },
+  {
+    id: "LANG.LAMBDA03",
+    pattern: () => ExpressionLang,
+    input: "(a b -> _)",
+    value: {
+      kind: LangExpressionKind.LambdaExpression,
+      pattern: {
+        kind: LangPatternKind.ThenPattern,
+        left: {
+          kind: LangPatternKind.ReferencePattern,
+          name: "a",
+        },
+        right: {
+          kind: LangPatternKind.ReferencePattern,
+          name: "b",
+        },
+      },
+      expression: {
+        kind: LangExpressionKind.ReferenceExpression,
+        name: "_",
+      },
+    },
+  },
+  {
+    id: "LANG.LAMBDA04",
+    pattern: () => ExpressionLang,
+
+    // this is ambiguous between a lambda expression
+    // and a projection pattern, because the pattern
+    // is PatternPattern vs the lower priority ThenPattern
+    // Should we have projec
+    input: "(a | b -> _)",
+    value: {
+      kind: LangExpressionKind.LambdaExpression,
+      pattern: {
+        kind: LangPatternKind.OrPattern,
+        left: {
+          kind: LangPatternKind.ReferencePattern,
+          name: "a",
+        },
+        right: {
+          kind: LangPatternKind.ReferencePattern,
+          name: "b",
+        },
+      },
+      expression: {
+        kind: LangExpressionKind.ReferenceExpression,
+        name: "_",
       },
     },
   },

--- a/src/parsers/lang/expressions/LambdaExpression.ts
+++ b/src/parsers/lang/expressions/LambdaExpression.ts
@@ -13,11 +13,18 @@ export const LambdaExpression: IRulePattern = {
           kind: PatternKind.Then,
           patterns: [
             {
+              kind: PatternKind.Object,
+              keys: {
+                type: { kind: PatternKind.Equal, value: "Token" },
+                value: { kind: PatternKind.Equal, value: "(" },
+              },
+            },
+            {
               kind: PatternKind.Variable,
               name: "pattern",
               pattern: {
                 kind: PatternKind.Reference,
-                name: LangPatternKind.ThenPattern,
+                name: LangPatternKind.PatternPattern,
               },
             },
             {
@@ -40,6 +47,13 @@ export const LambdaExpression: IRulePattern = {
               pattern: {
                 kind: PatternKind.Reference,
                 name: LangPatternKind.ExpressionPattern,
+              },
+            },
+            {
+              kind: PatternKind.Object,
+              keys: {
+                type: { kind: PatternKind.Equal, value: "Token" },
+                value: { kind: PatternKind.Equal, value: ")" },
               },
             },
           ],

--- a/src/parsers/lang/patterns/OrPattern.test.ts
+++ b/src/parsers/lang/patterns/OrPattern.test.ts
@@ -4,7 +4,7 @@ import { LangExpressionKind, LangPatternKind } from "../lang.pattern.ts";
 
 tests(() => [
   {
-    id: "ORPATTERN00",
+    id: "LANG.PATTERN.OR00",
     description: "can parse a reference expression",
     pattern: () => PatternLang,
     input: "x | y",
@@ -21,10 +21,10 @@ tests(() => [
     },
   },
   {
-    id: "ORPATTERN01",
+    id: "LANG.PATTERN.OR01",
     description: "can parse a projection expression",
     pattern: () => PatternLang,
-    input: "x -> $0 | y",
+    input: "(x -> $0) | y",
     value: {
       kind: LangPatternKind.OrPattern,
       left: {
@@ -45,8 +45,8 @@ tests(() => [
     },
   },
   {
-    id: "ORPATTERN02",
-    description: "can parse two then expressions",
+    id: "LANG.PATTERN.OR02",
+    description: "can parse two then patterns",
     pattern: () => PatternLang,
     input: "w x | y z",
     value: {

--- a/src/parsers/lang/patterns/PatternPattern.test.ts
+++ b/src/parsers/lang/patterns/PatternPattern.test.ts
@@ -4,7 +4,7 @@ import { IPipelinePattern, LangPatternKind } from "../lang.pattern.ts";
 
 tests(() => [
   {
-    id: "PEXPR00",
+    id: "LANG.PATTERN.PATTERN00",
     pattern: () => PatternLang,
     input: "a > b & c",
     value: {
@@ -27,7 +27,7 @@ tests(() => [
     } as IPipelinePattern,
   },
   {
-    id: "PEXPR01",
+    id: "LANG.PATTERN.PATTERN01",
     pattern: () => PatternLang,
     input: "a & b > c",
     value: {
@@ -50,7 +50,7 @@ tests(() => [
     } as IPipelinePattern,
   },
   {
-    id: "PEXPR02",
+    id: "LANG.PATTERN.PATTERN02",
     pattern: () => PatternLang,
     input: "a | b & c",
     value: {
@@ -64,9 +64,9 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR03",
+    id: "LANG.PATTERN.PATTERN03",
     pattern: () => PatternLang,
-    input: "a -> $0 | b",
+    input: "(a -> $0) | b",
     value: {
       kind: "OrPattern",
       left: {
@@ -78,9 +78,9 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR04",
+    id: "LANG.PATTERN.PATTERN04",
     pattern: () => PatternLang,
-    input: "a b -> $0",
+    input: "(a b -> $0)",
     value: {
       kind: "ProjectionPattern",
       pattern: {
@@ -92,7 +92,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR05",
+    id: "LANG.PATTERN.PATTERN05",
     pattern: () => PatternLang,
     input: "a! b",
     value: {
@@ -107,7 +107,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR06",
+    id: "LANG.PATTERN.PATTERN06",
     pattern: () => PatternLang,
     input: "^a!",
     value: {
@@ -121,7 +121,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR07",
+    id: "LANG.PATTERN.PATTERN07",
     pattern: () => PatternLang,
     input: "^a:b",
     value: {
@@ -134,7 +134,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR08",
+    id: "LANG.PATTERN.PATTERN08",
     pattern: () => PatternLang,
     input: "a:b+",
     value: {
@@ -147,7 +147,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR09",
+    id: "LANG.PATTERN.PATTERN09",
     pattern: () => PatternLang,
     input: "a:b*",
     value: {
@@ -160,7 +160,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR10",
+    id: "LANG.PATTERN.PATTERN10",
     pattern: () => PatternLang,
     input: "a:b?",
     value: {
@@ -173,31 +173,31 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR11",
+    id: "LANG.PATTERN.PATTERN11",
     pattern: () => PatternLang,
     input: "any*",
     value: { kind: "ZeroOrMorePattern", pattern: { kind: "AnyPattern" } },
   },
   {
-    id: "PEXPR12",
+    id: "LANG.PATTERN.PATTERN12",
     pattern: () => PatternLang,
     input: "ok*",
     value: { kind: "ZeroOrMorePattern", pattern: { kind: "OkPattern" } },
   },
   {
-    id: "PEXPR13",
+    id: "LANG.PATTERN.PATTERN13",
     pattern: () => PatternLang,
     input: "string*",
     value: { kind: "ZeroOrMorePattern", pattern: { kind: "StringPattern" } },
   },
   {
-    id: "PEXPR14",
+    id: "LANG.PATTERN.PATTERN14",
     pattern: () => PatternLang,
     input: "number*",
     value: { kind: "ZeroOrMorePattern", pattern: { kind: "NumberPattern" } },
   },
   {
-    id: "PEXPR15",
+    id: "LANG.PATTERN.PATTERN15",
     pattern: () => PatternLang,
     input: "$0*",
     value: {
@@ -206,7 +206,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR16",
+    id: "LANG.PATTERN.PATTERN16",
     pattern: () => PatternLang,
     input: "x*",
     value: {
@@ -215,7 +215,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR17",
+    id: "LANG.PATTERN.PATTERN17",
     pattern: () => PatternLang,
     input: "'abc'*",
     value: {
@@ -224,7 +224,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR18",
+    id: "LANG.PATTERN.PATTERN18",
     pattern: () => PatternLang,
     input: "1*",
     value: {
@@ -233,7 +233,7 @@ tests(() => [
     },
   },
   {
-    id: "PEXPR18",
+    id: "LANG.PATTERN.PATTERN18",
     pattern: () => PatternLang,
     input: "(x)*",
     value: {

--- a/src/parsers/lang/patterns/ProjectionPattern.test.ts
+++ b/src/parsers/lang/patterns/ProjectionPattern.test.ts
@@ -6,7 +6,7 @@ tests(() => [
   {
     id: "PROJECT00",
     pattern: () => PatternLang,
-    input: "x -> $0",
+    input: "(x -> $0)",
     value: {
       kind: LangPatternKind.ProjectionPattern,
       pattern: {
@@ -22,7 +22,7 @@ tests(() => [
   {
     id: "PROJECT01",
     pattern: () => PatternLang,
-    input: "x:y -> $0",
+    input: "(x:y -> $0)",
     value: {
       kind: LangPatternKind.ProjectionPattern,
       pattern: {

--- a/src/parsers/lang/patterns/ProjectionPattern.ts
+++ b/src/parsers/lang/patterns/ProjectionPattern.ts
@@ -13,6 +13,13 @@ export const ProjectionPattern: IRulePattern = {
           kind: PatternKind.Then,
           patterns: [
             {
+              kind: PatternKind.Object,
+              keys: {
+                type: { kind: PatternKind.Equal, value: "Token" },
+                value: { kind: PatternKind.Equal, value: "(" },
+              },
+            },
+            {
               kind: PatternKind.Variable,
               name: "pattern",
               pattern: { kind: PatternKind.Reference, name: "ThenPattern" },
@@ -37,6 +44,13 @@ export const ProjectionPattern: IRulePattern = {
               pattern: {
                 kind: PatternKind.Reference,
                 name: LangPatternKind.ExpressionPattern,
+              },
+            },
+            {
+              kind: PatternKind.Object,
+              keys: {
+                type: { kind: PatternKind.Equal, value: "Token" },
+                value: { kind: PatternKind.Equal, value: ")" },
               },
             },
           ],

--- a/src/runtime/patterns/block.ts
+++ b/src/runtime/patterns/block.ts
@@ -2,14 +2,20 @@ import { Scope } from "../../scope.ts";
 import { Match } from "../../match.ts";
 import { match } from "../match.ts";
 import { IBlockPattern } from "./pattern.ts";
+import { blue } from "../../../deps/std.ts";
 
 export function block(args: IBlockPattern, scope: Scope): Match {
   const { rules } = args;
-  const pattern = Object.entries(rules).pop()?.[1];
+  const [name, pattern] = Object.entries(rules).pop() ?? [];
   if (pattern) {
     const subScope = scope
       .setRules(rules)
       .push();
+
+    if (scope.options.trace) {
+      const indent = "›".padStart(subScope.depth);
+      console.log(`${indent} ${blue(name ?? pattern.kind)}`);
+    }
 
     const result = match(pattern, subScope);
     return result.pop();

--- a/src/runtime/patterns/reference.ts
+++ b/src/runtime/patterns/reference.ts
@@ -3,22 +3,35 @@ import { Match } from "../../match.ts";
 import { match } from "../match.ts";
 import { IReferencePattern } from "./pattern.ts";
 import { RuntimeError, RuntimeErrorCode } from "../runtime.error.ts";
+import {
+  brightBlack,
+  green,
+  red,
+} from "../../../deps/std.ts";
 
 export function reference(args: IReferencePattern, scope: Scope): Match {
   const { name } = args;
   const rule = scope.getRule(name);
   if (rule) {
     if (scope.options.trace) {
-      console.log(
-        `#${name}: ${scope.stream.path} (${
-          Deno.inspect(scope.stream.value, { colors: true, depth: 10 })
-        })`,
-      );
+      const indent = "›".padStart(scope.depth);
+      console.log(`${indent} ${brightBlack(name)}`);
     }
 
     const s = scope.pushRef(name);
     const m = match(rule, s);
-    return m.popRef(scope);
+    const r = m.popRef(scope);
+
+    if (scope.options.trace) {
+      const indent = "›".padStart(scope.depth);
+      if (m.matched) {
+        console.log(`${indent} ${green(name)}`);
+      } else {
+        console.log(`${indent} ${red(name)}`);
+      }
+    }
+
+    return r;
   } else {
     throw new RuntimeError(
       RuntimeErrorCode.PatternNotFound,

--- a/src/uffda.ts
+++ b/src/uffda.ts
@@ -1,4 +1,4 @@
-import { Scope } from "./scope.ts";
+import { IScopeOptions, Scope } from "./scope.ts";
 import { Meta } from "./parsers/meta.ts";
 import { match } from "./runtime/mod.ts";
 import { ProjectionFunction } from "./runtime/expressions/mod.ts";
@@ -26,14 +26,14 @@ const argsToSpecials = (args: (ProjectionFunction | IRulePattern)[]) =>
 //   return dsl(value as Pattern);
 // }
 
-export function dsl(pattern: Pattern) {
+export function dsl(pattern: Pattern, options?: IScopeOptions) {
   return (
     template: TemplateStringsArray,
     ...args: (ProjectionFunction | IRulePattern)[]
   ) => {
     const dslCode = templateToCode(template);
     const specials = argsToSpecials(args);
-    const scope = Scope.From(dslCode).setSpecials(specials);
+    const scope = Scope.From(dslCode, options).setSpecials(specials);
     return match(pattern, scope);
   };
 }


### PR DESCRIPTION
Multiple fixes for lambda expressions:

- Added lots more tests
- Added Number expressions
- Had to wrap both lambda and projections with `( )` to prevent ambiguities
- Fixed a _major_ bug related to tracing not popping rules and refs properly at all