### PR TITLE
fix: explicitly define default exports

### DIFF
--- a/src/lang/common/characters/combining.ts
+++ b/src/lang/common/characters/combining.ts
@@ -8,6 +8,7 @@ export const Combining: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Combining",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/characters/connecting.ts
+++ b/src/lang/common/characters/connecting.ts
@@ -8,6 +8,7 @@ export const Connecting: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Connecting",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/characters/digit.ts
+++ b/src/lang/common/characters/digit.ts
@@ -8,6 +8,7 @@ export const Digit: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Digit",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/characters/formatting.ts
+++ b/src/lang/common/characters/formatting.ts
@@ -8,6 +8,7 @@ export const Formatting: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Formatting",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/characters/letter.ts
+++ b/src/lang/common/characters/letter.ts
@@ -8,6 +8,7 @@ export const Letter: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Letter",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/characters/newLine.ts
+++ b/src/lang/common/characters/newLine.ts
@@ -9,6 +9,7 @@ export const NewLine: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "NewLine",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/characters/whitespace.ts
+++ b/src/lang/common/characters/whitespace.ts
@@ -9,6 +9,7 @@ export const Whitespace: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Whitespace",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/identifier.ts
+++ b/src/lang/common/identifier.ts
@@ -78,6 +78,7 @@ export const Identifier: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Identifier",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/common/surround.test.ts
+++ b/src/lang/common/surround.test.ts
@@ -90,6 +90,7 @@ export const SurroundTest: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "SurroundTest",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/binary.ts
+++ b/src/lang/expression/binary.ts
@@ -24,6 +24,7 @@ export const Binary: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Binary",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/expression.md
+++ b/src/lang/expression/expression.md
@@ -1,6 +1,9 @@
 Expression Language Notes
 
 ```uff
+import "../tokenizer/token.ts" Token;
+import "./string.ts" String;
+
 Expression = Binary
 
 Binary
@@ -26,13 +29,11 @@ Primary =
   ;
 
 Terminal =
-  | Reference // x
-  | Number    // 1
+  | Token<Reference> // x
+  | Token<Number>    // 1
   ;
 
 Sequence = "(" Expression+ ")"
-
-String = "\"" (not "\"" and string)* "\""
 
 // Terminals
 Reference = string >> Identifier // x
@@ -42,4 +43,40 @@ Reference = string >> Identifier // x
 // - handle floats
 // - handle hex
 Number = string >> Digit+ -> parseInt(join("" _)) // 123
+```
+
+#### string
+
+```uff
+import "./primary.ts" Primary;
+
+// todo: should also probably suport escaped \
+EscapedCurlBegin = "\\\\" "\{" -> "\{";
+EscapedDoubleQuote = "\\\\" "\"" -> "\"";
+EscapedString =
+  | EscapedCurlyBegin
+  | EscapedDoubleQuote
+  ;
+StringExpression =
+  "\{"
+  v:Primary
+  "}"
+  -> v
+  ;
+StringContent =
+  (
+  | EscapedString
+  | (not "\{" & not "\"")
+  )+ -> (join, "", _)
+  ;
+
+export String =
+  "\""
+  v:(StringExpression | StringContent)*
+  "\""
+  -> {
+    kind: ExpressionKind.String,
+    values: v
+  }
+  ;
 ```

--- a/src/lang/expression/expression.ts
+++ b/src/lang/expression/expression.ts
@@ -19,6 +19,7 @@ export const Expression: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Expression",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/mod.ts
+++ b/src/lang/expression/mod.ts
@@ -1,7 +1,13 @@
+import { ImportDeclarationKind } from "../../runtime/declarations/import.ts";
 import type { ModuleDeclaration } from "../../runtime/declarations/module.ts";
 
 export const Expression: ModuleDeclaration = {
-  imports: [],
+  imports: [
+    {
+      kind: ImportDeclarationKind.Module,
+      moduleUrl: "../tokenizer/mod.ts",
+    },
+  ],
   exports: [],
   rules: [],
 };

--- a/src/lang/expression/number.ts
+++ b/src/lang/expression/number.ts
@@ -20,6 +20,7 @@ export const Number: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Number",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/primary.ts
+++ b/src/lang/expression/primary.ts
@@ -36,6 +36,7 @@ export const Terminal: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Primary",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/reference.ts
+++ b/src/lang/expression/reference.ts
@@ -20,6 +20,7 @@ export const Reference: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Reference",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/sequence.ts
+++ b/src/lang/expression/sequence.ts
@@ -19,6 +19,7 @@ export const Sequence: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Sequence",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/string.ts
+++ b/src/lang/expression/string.ts
@@ -20,6 +20,7 @@ export const String: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "String",
+      default: true,
     },
   ],
   rules: [
@@ -99,7 +100,7 @@ export const String: ModuleDeclaration = {
             name: "v",
             pattern: {
               kind: PatternKind.Reference,
-              name: "Primary",
+              name: "Primary", // todo: this should be Expression
               args: [],
             },
           },

--- a/src/lang/expression/terminal.ts
+++ b/src/lang/expression/terminal.ts
@@ -33,6 +33,7 @@ export const Terminal: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Terminal",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/expression/unary.ts
+++ b/src/lang/expression/unary.ts
@@ -23,6 +23,7 @@ export const Unary: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "Unary",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/tokenizer/mod.ts
+++ b/src/lang/tokenizer/mod.ts
@@ -32,12 +32,13 @@ export const Tokenizer: ModuleDeclaration = {
   ],
   exports: [
     {
-      kind: ExportDeclarationKind.Rule,
-      name: "Main",
-    },
-    {
       kind: ExportDeclarationKind.Import,
       name: "Token",
+    },
+    {
+      kind: ExportDeclarationKind.Rule,
+      name: "Tokenizer",
+      default: true,
     },
   ],
   rules: [
@@ -147,7 +148,7 @@ export const Tokenizer: ModuleDeclaration = {
       },
     },
     {
-      name: "Main",
+      name: "Tokenizer",
       parameters: [],
       pattern: {
         kind: PatternKind.Slice,

--- a/src/lang/tokenizer/token.test.ts
+++ b/src/lang/tokenizer/token.test.ts
@@ -72,6 +72,7 @@ export const TokenTest: ModuleDeclaration = {
     {
       kind: ExportDeclarationKind.Rule,
       name: "TokenTest",
+      default: true,
     },
   ],
   rules: [

--- a/src/lang/tokenizer/tokenizer.test.ts
+++ b/src/lang/tokenizer/tokenizer.test.ts
@@ -22,6 +22,7 @@ Deno.test({
         kind: MatchKind.Ok,
       }),
     });
+
     await t.step({
       name: "TOKENIZER01",
       fn: moduleDeclarationTest({

--- a/src/runtime/declarations/export.ts
+++ b/src/runtime/declarations/export.ts
@@ -10,9 +10,11 @@ export enum ExportDeclarationKind {
 export type ImportExportDeclaration = {
   kind: ExportDeclarationKind.Import;
   name: string;
+  default?: boolean;
 };
 
 export type RuleExportDeclaration = {
   kind: ExportDeclarationKind.Rule;
   name: string;
+  default?: boolean;
 };

--- a/src/runtime/modules/module.ts
+++ b/src/runtime/modules/module.ts
@@ -5,6 +5,7 @@ export type Module = {
   imports: Map<string, Rule>;
   exports: Map<string, Rule>;
   rules: Map<string, Rule>;
+  default: Rule | undefined;
 };
 
 export const DefaultModule: () => Module = () => ({
@@ -12,4 +13,5 @@ export const DefaultModule: () => Module = () => ({
   imports: new Map(),
   exports: new Map(),
   rules: new Map(),
+  default: undefined,
 });

--- a/src/runtime/patterns/pipeline.test.ts
+++ b/src/runtime/patterns/pipeline.test.ts
@@ -13,7 +13,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "Test",
@@ -41,7 +45,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "One",
@@ -102,7 +110,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "PlusOne",
@@ -163,7 +175,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "P",
@@ -208,7 +224,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "P",
@@ -252,7 +272,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "P",
@@ -307,7 +331,11 @@ Deno.test("runtime.patterns.pipeline", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Test" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Test",
+            default: true,
+          }],
           rules: [
             {
               name: "Test",

--- a/src/runtime/patterns/reference.test.ts
+++ b/src/runtime/patterns/reference.test.ts
@@ -16,7 +16,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "A",
@@ -48,7 +52,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "A",
@@ -91,7 +99,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "A",
@@ -137,7 +149,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "A",
@@ -172,7 +188,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "A",
@@ -213,7 +233,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "A",
@@ -260,7 +284,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
               names: ["A"],
             },
           ],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "B",
@@ -281,7 +309,7 @@ Deno.test("runtime.patterns.reference", async (t) => {
         ["file:///a.ts"]: {
           imports: [],
           exports: [
-            { kind: ExportDeclarationKind.Rule, name: "A" },
+            { kind: ExportDeclarationKind.Rule, name: "A", default: true },
           ],
           rules: [
             // Rule A is defined in a separate module
@@ -319,7 +347,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
               names: ["A"],
             },
           ],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             // Rule B is passed as an argument for parameter T into rule A
             // Yet rule B is still able to access rule C since it is resolving references in its context
@@ -350,7 +382,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
         },
         ["file:///a.ts"]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "A" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "A",
+            default: true,
+          }],
           rules: [
             // Rule A is defined in a separate module
             // But it is still able to access rule B since it is passed as an argument for parameter T
@@ -387,7 +423,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
               names: ["A"],
             },
           ],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "B",
@@ -416,7 +456,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
         },
         ["file:///a.ts"]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "A" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "A",
+            default: true,
+          }],
           rules: [
             // Rule A is not able to access rule C since it is scoped to a different module
             {
@@ -455,7 +499,11 @@ Deno.test("runtime.patterns.reference", async (t) => {
               names: ["A"],
             },
           ],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "Main" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "Main",
+            default: true,
+          }],
           rules: [
             {
               name: "B",

--- a/src/runtime/patterns/run.ts
+++ b/src/runtime/patterns/run.ts
@@ -6,22 +6,21 @@ import type { RunPattern } from "./pattern.ts";
 
 export function run(scope: Scope, pattern: RunPattern): Match {
   const { module } = scope;
-  const { name = "Main" } = pattern;
+  const { name } = pattern;
 
   // Main rule selection:
   // 1. If the caller specifies a pattern name, use that
-  // 2. Look for a rule called Main
-  // 3. Use the last rule in the module
-  const main = module.exports.has(name)
-    ? module.exports.get(name)
-    : [...module.exports.values()].slice(-1)[0];
+  // 2. Use the default pattern
+  const main = name ? module.exports.get(name) : module.default;
 
   if (!main) {
     return error(
       scope,
       pattern,
       MatchErrorCode.PatternExpected,
-      `Rule ${name} not found`,
+      name
+        ? `Rule ${name} not found`
+        : `Module does not have a default export, please specify which Rule you want to import`,
     );
   }
 

--- a/src/runtime/patterns/special.test.ts
+++ b/src/runtime/patterns/special.test.ts
@@ -12,12 +12,14 @@ const mod0: Module = {
   imports: new Map(),
   exports: new Map(),
   rules: new Map(),
+  default: undefined,
 };
 const mod1: Module = {
   moduleUrl: new URL("file:///t1.ts"),
   imports: new Map(),
   exports: new Map(),
   rules: new Map(),
+  default: undefined,
 };
 const rule: Rule = {
   name: "A",
@@ -29,6 +31,7 @@ const rule: Rule = {
 };
 mod0.rules.set("A", rule);
 mod0.exports.set("A", rule);
+mod0.default = rule;
 
 Deno.test("runtime.patterns.special", async (t) => {
   await t.step({
@@ -78,7 +81,8 @@ Deno.test("runtime.patterns.special", async (t) => {
       },
       kind: MatchKind.Error,
       code: MatchErrorCode.PatternExpected,
-      message: "Rule Main not found",
+      message:
+        "Module does not have a default export, please specify which Rule you want to import",
       start: Path.From(0),
       end: Path.From(0),
     }),

--- a/src/runtime/resolve.ts
+++ b/src/runtime/resolve.ts
@@ -42,6 +42,7 @@ export class Resolver {
         imports: new Map(),
         exports: new Map(),
         rules: new Map(),
+        default: undefined,
       };
       this.modules.set(moduleUrl.href, module);
       const moduleDeclaration = await this.importModule(moduleUrl);
@@ -68,6 +69,14 @@ export class Resolver {
               throw new Error(`Unknown rule ${name}`);
             }
             module.exports.set(name, rule);
+            if (e.default) {
+              if (module.default) {
+                throw new Error(
+                  `Module ${name} cannot have multiple default exports`,
+                );
+              }
+              module.default = rule;
+            }
             break;
           }
         }
@@ -118,6 +127,14 @@ export class Resolver {
               throw new Error(`Unknown import ${name}`);
             }
             module.exports.set(name, resolvedImport);
+            if (e.default) {
+              if (module.default) {
+                throw new Error(
+                  `Module ${name} cannot have multiple default exports`,
+                );
+              }
+              module.default = resolvedImport;
+            }
             break;
           }
         }

--- a/src/runtime/rule.test.ts
+++ b/src/runtime/rule.test.ts
@@ -17,7 +17,11 @@ Deno.test("runtime.rule", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "R" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "R",
+            default: true,
+          }],
           rules: [
             {
               name: "R",
@@ -43,7 +47,11 @@ Deno.test("runtime.rule", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "a" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "a",
+            default: true,
+          }],
           rules: [
             {
               // a = a | 'a'
@@ -81,7 +89,11 @@ Deno.test("runtime.rule", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "a" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "a",
+            default: true,
+          }],
           rules: [
             {
               name: "a",
@@ -119,7 +131,7 @@ Deno.test("runtime.rule", async (t) => {
           imports: [],
           exports: [
             { kind: ExportDeclarationKind.Rule, name: "a" },
-            { kind: ExportDeclarationKind.Rule, name: "b" },
+            { kind: ExportDeclarationKind.Rule, name: "b", default: true },
           ],
           rules: [
             {
@@ -155,7 +167,11 @@ Deno.test("runtime.rule", async (t) => {
       declarations: {
         [import.meta.url]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "a" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "a",
+            default: true,
+          }],
           rules: [
             {
               // a = 'a' a | 'a'
@@ -193,7 +209,7 @@ Deno.test("runtime.rule", async (t) => {
           imports: [],
           exports: [
             { kind: ExportDeclarationKind.Rule, name: "P0" },
-            { kind: ExportDeclarationKind.Rule, name: "P1" },
+            { kind: ExportDeclarationKind.Rule, name: "P1", default: true },
           ],
           rules: [
             {
@@ -246,7 +262,7 @@ Deno.test("runtime.rule", async (t) => {
           imports: [],
           exports: [
             { kind: ExportDeclarationKind.Rule, name: "P0" },
-            { kind: ExportDeclarationKind.Rule, name: "P1" },
+            { kind: ExportDeclarationKind.Rule, name: "P1", default: true },
           ],
           rules: [
             {
@@ -293,7 +309,11 @@ Deno.test("runtime.rule", async (t) => {
       declarations: {
         ["file:///m0.ts"]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "P0" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "P0",
+            default: true,
+          }],
           rules: [
             {
               name: "P0",
@@ -316,7 +336,11 @@ Deno.test("runtime.rule", async (t) => {
               names: ["P0"],
             },
           ],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "P1" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "P1",
+            default: true,
+          }],
           rules: [
             {
               name: "P1",
@@ -355,7 +379,11 @@ Deno.test("runtime.rule", async (t) => {
       declarations: {
         ["file:///m0.ts"]: {
           imports: [],
-          exports: [{ kind: ExportDeclarationKind.Rule, name: "P0" }],
+          exports: [{
+            kind: ExportDeclarationKind.Rule,
+            name: "P0",
+            default: true,
+          }],
           rules: [
             {
               name: "P0",

--- a/src/test.ts
+++ b/src/test.ts
@@ -233,7 +233,11 @@ export function ruleTest(options: RuleTestOptions) {
         "file:///test.ts": {
           imports: [],
           exports: [
-            { kind: ExportDeclarationKind.Rule, name: rule.name },
+            {
+              kind: ExportDeclarationKind.Rule,
+              name: rule.name,
+              default: true,
+            },
           ],
           rules: [rule],
         },
@@ -330,7 +334,7 @@ function assertLR(m: MatchLR, assertion: MatchAssertion) {
 function assertError(m: MatchError, assertion: MatchAssertion) {
   assert(
     m.kind === assertion.kind,
-    `Match was ${m.kind} with message ${m.message} but expected to be ${assertion.kind}`,
+    `Match was [${m.kind}] with message "${m.message}" but expected to be [${assertion.kind}]`,
   );
   assert(
     m.message === assertion.message,
@@ -395,7 +399,7 @@ function assertFail(m: MatchFail, assertion: MatchAssertion) {
 function assertOk(m: MatchOk, assertion: MatchAssertion) {
   assert(
     m.kind === assertion.kind,
-    `Match was ${m.kind} but expected to be ${assertion.kind}`,
+    `Match was [${m.kind}] but expected to be ${assertion.kind}`,
   );
   assert(
     equal(m.value, assertion.value),


### PR DESCRIPTION
Turns out the "last" element in a Map is not deterministic. Also, its kind of lame so I'm just going to require the default be explicitly defined.